### PR TITLE
Use 4/8LI for coderate

### DIFF
--- a/packet_forwarder/src/lora_pkt_fwd.c
+++ b/packet_forwarder/src/lora_pkt_fwd.c
@@ -1319,7 +1319,7 @@ void thread_up(void) {
                 /* Packet ECC coding rate, 11-13 useful chars */
                 switch (p->coderate) {
                     case CR_LORA_LI_4_7:
-                        memcpy((void *)(buff_up + buff_index), (void *)",\"codr\":\"4/7LI\"", 15);
+                        memcpy((void *)(buff_up + buff_index), (void *)",\"codr\":\"4/8LI\"", 15);
                         buff_index += 15;
                         break;
                     default:
@@ -1683,7 +1683,7 @@ void thread_down(void) {
                 json_value_free(root_val);
                 continue;
             }
-            if ((strcmp(str, "4/7LI") == 0) || (strcmp(str, "4/8") == 0)) {
+            if ((strcmp(str, "4/7LI") == 0) || (strcmp(str, "4/8LI") == 0)) {
                 txpkt.coderate = CR_LORA_LI_4_7;
             } else {
                 MSG("WARNING: [down] format error in \"txpk.codr\", TX aborted\n");


### PR DESCRIPTION
Uplinks and downlinks were using only 4/7LI strings